### PR TITLE
Consumers can claim 0 partitions without crashing

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -121,7 +121,7 @@ module Kafka
         # run the same algorithm on the same sorted lists of instances and partitions,
         # all instances should be in agreement of the distribtion.
         distributed_partitions = self.class.distribute_partitions(running_instances, partitions)
-        my_partitions = distributed_partitions[@instance]
+        my_partitions = distributed_partitions.fetch(@instance, [])
 
         logger.info "Claiming #{my_partitions.length} out of #{partitions.length} partitions."
 


### PR DESCRIPTION
While having more consumers than partitions isn't ideal, it shouldn't cause consumers to crash. Currently having more consumers than partitions causes at least one (sometimes more) consumers to crash.
